### PR TITLE
feat: updating GAPIC and bumping semver minor version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/bigquery-data-transfer",
   "description": "BigQuery Data Transfer API client for Node.js",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {

--- a/protos/google/cloud/bigquery/datatransfer/v1/datatransfer.proto
+++ b/protos/google/cloud/bigquery/datatransfer/v1/datatransfer.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -97,7 +97,7 @@ service DataTransferService {
     };
   }
 
-  // Creates transfer runs for a time range [range_start_time, range_end_time].
+  // Creates transfer runs for a time range [start_time, end_time].
   // For each date - or whatever granularity the data source supports - in the
   // range, one transfer run is created.
   // Note that runs are created per UTC time in the time range.
@@ -339,7 +339,7 @@ message DataSource {
   // for the data source.
   bool manual_runs_disabled = 17;
 
-  // The minimum interval between two consecutive scheduled runs.
+  // The minimum interval for scheduler to schedule runs.
   google.protobuf.Duration minimum_schedule_interval = 18;
 }
 
@@ -388,10 +388,8 @@ message ListDataSourcesResponse {
 message CreateTransferConfigRequest {
   // The BigQuery project id where the transfer configuration should be created.
   // Must be in the format /projects/{project_id}/locations/{location_id}
-  // or
-  // /projects/{project_id}/locations/-
-  // In case when '-' is specified as location_id, location is infered from
-  // the destination dataset region.
+  // If specified location and location of the destination bigquery dataset
+  // do not match - the request will fail.
   string parent = 1;
 
   // Data transfer configuration to create.

--- a/protos/google/cloud/bigquery/datatransfer/v1/transfer.proto
+++ b/protos/google/cloud/bigquery/datatransfer/v1/transfer.proto
@@ -1,4 +1,4 @@
-// Copyright 2017 Google Inc.
+// Copyright 2018 Google Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,6 +35,7 @@ option php_namespace = "Google\\Cloud\\BigQuery\\DataTransfer\\V1";
 // When a new transfer configuration is created, the specified
 // `destination_dataset_id` is created when needed and shared with the
 // appropriate data source service account.
+// Next id: 20
 message TransferConfig {
   // The resource name of the transfer config.
   // Transfer config names have the form
@@ -94,6 +95,8 @@ message TransferConfig {
   // Output only. Unique ID of the user on whose behalf transfer is done.
   // Applicable only to data sources that do not support service accounts.
   // When set to 0, the data source service account credentials are used.
+  // May be negative. Note, that this identifier is not stable.
+  // It may change over time even for the same user.
   int64 user_id = 11;
 
   // Output only. Region in which BigQuery dataset is located.
@@ -101,7 +104,7 @@ message TransferConfig {
 }
 
 // Represents a data transfer run.
-// Next id: 23
+// Next id: 27
 message TransferRun {
   // The resource name of the transfer run.
   // Transfer run names have the form
@@ -109,18 +112,15 @@ message TransferRun {
   // The name is ignored when creating a transfer run.
   string name = 1;
 
-  // The BigQuery target dataset id.
-  string destination_dataset_id = 2;
-
   // Minimum time after which a transfer run can be started.
   google.protobuf.Timestamp schedule_time = 3;
-
-  // Data transfer specific parameters.
-  google.protobuf.Struct params = 9;
 
   // For batch transfer runs, specifies the date and time that
   // data should be ingested.
   google.protobuf.Timestamp run_time = 10;
+
+  // Status of the transfer run.
+  google.rpc.Status error_status = 21;
 
   // Output only. Time when transfer run was started.
   // Parameter ignored by server for input requests.
@@ -133,6 +133,12 @@ message TransferRun {
   // Output only. Last time the data transfer run state was updated.
   google.protobuf.Timestamp update_time = 6;
 
+  // Output only. Data transfer specific parameters.
+  google.protobuf.Struct params = 9;
+
+  // Output only. The BigQuery target dataset id.
+  string destination_dataset_id = 2;
+
   // Output only. Data source id.
   string data_source_id = 7;
 
@@ -142,7 +148,8 @@ message TransferRun {
   // Output only. Unique ID of the user on whose behalf transfer is done.
   // Applicable only to data sources that do not support service accounts.
   // When set to 0, the data source service account credentials are used.
-  // May be negative.
+  // May be negative. Note, that this identifier is not stable.
+  // It may change over time even for the same user.
   int64 user_id = 11;
 
   // Output only. Describes the schedule of this transfer run if it was
@@ -197,9 +204,6 @@ enum TransferType {
 enum TransferState {
   // State placeholder.
   TRANSFER_STATE_UNSPECIFIED = 0;
-
-  // Data transfer is inactive.
-  INACTIVE = 1;
 
   // Data transfer is scheduled and is waiting to be picked up by
   // data transfer backend.

--- a/smoke-test/data_transfer_service_smoke_test.js
+++ b/smoke-test/data_transfer_service_smoke_test.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/data_transfer_service_client.js
+++ b/src/v1/data_transfer_service_client.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -224,11 +224,7 @@ class DataTransferServiceClient {
    * in this service.
    */
   static get scopes() {
-    return [
-      'https://www.googleapis.com/auth/bigquery',
-      'https://www.googleapis.com/auth/cloud-platform',
-      'https://www.googleapis.com/auth/cloud-platform.read-only',
-    ];
+    return ['https://www.googleapis.com/auth/cloud-platform'];
   }
 
   /**
@@ -452,10 +448,8 @@ class DataTransferServiceClient {
    * @param {string} request.parent
    *   The BigQuery project id where the transfer configuration should be created.
    *   Must be in the format /projects/{project_id}/locations/{location_id}
-   *   or
-   *   /projects/{project_id}/locations/-
-   *   In case when '-' is specified as location_id, location is infered from
-   *   the destination dataset region.
+   *   If specified location and location of the destination bigquery dataset
+   *   do not match - the request will fail.
    * @param {Object} request.transferConfig
    *   Data transfer configuration to create.
    *
@@ -839,7 +833,7 @@ class DataTransferServiceClient {
   }
 
   /**
-   * Creates transfer runs for a time range [range_start_time, range_end_time].
+   * Creates transfer runs for a time range [start_time, end_time].
    * For each date - or whatever granularity the data source supports - in the
    * range, one transfer run is created.
    * Note that runs are created per UTC time in the time range.

--- a/src/v1/doc/google/cloud/bigquery/datatransfer/v1/doc_datatransfer.js
+++ b/src/v1/doc/google/cloud/bigquery/datatransfer/v1/doc_datatransfer.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -214,7 +214,7 @@ var DataSourceParameter = {
  *   for the data source.
  *
  * @property {Object} minimumScheduleInterval
- *   The minimum interval between two consecutive scheduled runs.
+ *   The minimum interval for scheduler to schedule runs.
  *
  *   This object should have the same structure as [Duration]{@link google.protobuf.Duration}
  *
@@ -353,10 +353,8 @@ var ListDataSourcesResponse = {
  * @property {string} parent
  *   The BigQuery project id where the transfer configuration should be created.
  *   Must be in the format /projects/{project_id}/locations/{location_id}
- *   or
- *   /projects/{project_id}/locations/-
- *   In case when '-' is specified as location_id, location is infered from
- *   the destination dataset region.
+ *   If specified location and location of the destination bigquery dataset
+ *   do not match - the request will fail.
  *
  * @property {Object} transferConfig
  *   Data transfer configuration to create.

--- a/src/v1/doc/google/cloud/bigquery/datatransfer/v1/doc_transfer.js
+++ b/src/v1/doc/google/cloud/bigquery/datatransfer/v1/doc_transfer.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -22,6 +22,7 @@
  * When a new transfer configuration is created, the specified
  * `destination_dataset_id` is created when needed and shared with the
  * appropriate data source service account.
+ * Next id: 20
  *
  * @property {string} name
  *   The resource name of the transfer config.
@@ -90,6 +91,8 @@
  *   Output only. Unique ID of the user on whose behalf transfer is done.
  *   Applicable only to data sources that do not support service accounts.
  *   When set to 0, the data source service account credentials are used.
+ *   May be negative. Note, that this identifier is not stable.
+ *   It may change over time even for the same user.
  *
  * @property {string} datasetRegion
  *   Output only. Region in which BigQuery dataset is located.
@@ -104,7 +107,7 @@ var TransferConfig = {
 
 /**
  * Represents a data transfer run.
- * Next id: 23
+ * Next id: 27
  *
  * @property {string} name
  *   The resource name of the transfer run.
@@ -112,24 +115,21 @@ var TransferConfig = {
  *   `projects/{project_id}/locations/{location}/transferConfigs/{config_id}/runs/{run_id}`.
  *   The name is ignored when creating a transfer run.
  *
- * @property {string} destinationDatasetId
- *   The BigQuery target dataset id.
- *
  * @property {Object} scheduleTime
  *   Minimum time after which a transfer run can be started.
  *
  *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
- *
- * @property {Object} params
- *   Data transfer specific parameters.
- *
- *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
  *
  * @property {Object} runTime
  *   For batch transfer runs, specifies the date and time that
  *   data should be ingested.
  *
  *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
+ *
+ * @property {Object} errorStatus
+ *   Status of the transfer run.
+ *
+ *   This object should have the same structure as [Status]{@link google.rpc.Status}
  *
  * @property {Object} startTime
  *   Output only. Time when transfer run was started.
@@ -148,6 +148,14 @@ var TransferConfig = {
  *
  *   This object should have the same structure as [Timestamp]{@link google.protobuf.Timestamp}
  *
+ * @property {Object} params
+ *   Output only. Data transfer specific parameters.
+ *
+ *   This object should have the same structure as [Struct]{@link google.protobuf.Struct}
+ *
+ * @property {string} destinationDatasetId
+ *   Output only. The BigQuery target dataset id.
+ *
  * @property {string} dataSourceId
  *   Output only. Data source id.
  *
@@ -160,7 +168,8 @@ var TransferConfig = {
  *   Output only. Unique ID of the user on whose behalf transfer is done.
  *   Applicable only to data sources that do not support service accounts.
  *   When set to 0, the data source service account credentials are used.
- *   May be negative.
+ *   May be negative. Note, that this identifier is not stable.
+ *   It may change over time even for the same user.
  *
  * @property {string} schedule
  *   Output only. Describes the schedule of this transfer run if it was
@@ -267,11 +276,6 @@ var TransferState = {
    * State placeholder.
    */
   TRANSFER_STATE_UNSPECIFIED: 0,
-
-  /**
-   * Data transfer is inactive.
-   */
-  INACTIVE: 1,
 
   /**
    * Data transfer is scheduled and is waiting to be picked up by

--- a/src/v1/doc/google/protobuf/doc_any.js
+++ b/src/v1/doc/google/protobuf/doc_any.js
@@ -1,0 +1,131 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * `Any` contains an arbitrary serialized protocol buffer message along with a
+ * URL that describes the type of the serialized message.
+ *
+ * Protobuf library provides support to pack/unpack Any values in the form
+ * of utility functions or additional generated methods of the Any type.
+ *
+ * Example 1: Pack and unpack a message in C++.
+ *
+ *     Foo foo = ...;
+ *     Any any;
+ *     any.PackFrom(foo);
+ *     ...
+ *     if (any.UnpackTo(&foo)) {
+ *       ...
+ *     }
+ *
+ * Example 2: Pack and unpack a message in Java.
+ *
+ *     Foo foo = ...;
+ *     Any any = Any.pack(foo);
+ *     ...
+ *     if (any.is(Foo.class)) {
+ *       foo = any.unpack(Foo.class);
+ *     }
+ *
+ *  Example 3: Pack and unpack a message in Python.
+ *
+ *     foo = Foo(...)
+ *     any = Any()
+ *     any.Pack(foo)
+ *     ...
+ *     if any.Is(Foo.DESCRIPTOR):
+ *       any.Unpack(foo)
+ *       ...
+ *
+ *  Example 4: Pack and unpack a message in Go
+ *
+ *      foo := &pb.Foo{...}
+ *      any, err := ptypes.MarshalAny(foo)
+ *      ...
+ *      foo := &pb.Foo{}
+ *      if err := ptypes.UnmarshalAny(any, foo); err != nil {
+ *        ...
+ *      }
+ *
+ * The pack methods provided by protobuf library will by default use
+ * 'type.googleapis.com/full.type.name' as the type URL and the unpack
+ * methods only use the fully qualified type name after the last '/'
+ * in the type URL, for example "foo.bar.com/x/y.z" will yield type
+ * name "y.z".
+ *
+ *
+ * # JSON
+ *
+ * The JSON representation of an `Any` value uses the regular
+ * representation of the deserialized, embedded message, with an
+ * additional field `@type` which contains the type URL. Example:
+ *
+ *     package google.profile;
+ *     message Person {
+ *       string first_name = 1;
+ *       string last_name = 2;
+ *     }
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.profile.Person",
+ *       "firstName": <string>,
+ *       "lastName": <string>
+ *     }
+ *
+ * If the embedded message type is well-known and has a custom JSON
+ * representation, that representation will be embedded adding a field
+ * `value` which holds the custom JSON in addition to the `@type`
+ * field. Example (for message google.protobuf.Duration):
+ *
+ *     {
+ *       "@type": "type.googleapis.com/google.protobuf.Duration",
+ *       "value": "1.212s"
+ *     }
+ *
+ * @property {string} typeUrl
+ *   A URL/resource name whose content describes the type of the
+ *   serialized protocol buffer message.
+ *
+ *   For URLs which use the scheme `http`, `https`, or no scheme, the
+ *   following restrictions and interpretations apply:
+ *
+ *   * If no scheme is provided, `https` is assumed.
+ *   * The last segment of the URL's path must represent the fully
+ *     qualified name of the type (as in `path/google.protobuf.Duration`).
+ *     The name should be in a canonical form (e.g., leading "." is
+ *     not accepted).
+ *   * An HTTP GET on the URL must yield a google.protobuf.Type
+ *     value in binary format, or produce an error.
+ *   * Applications are allowed to cache lookup results based on the
+ *     URL, or have them precompiled into a binary to avoid any
+ *     lookup. Therefore, binary compatibility needs to be preserved
+ *     on changes to types. (Use versioned type names to manage
+ *     breaking changes.)
+ *
+ *   Schemes other than `http`, `https` (or the empty scheme) might be
+ *   used with implementation specific semantics.
+ *
+ * @property {string} value
+ *   Must be a valid serialized protocol buffer of the above specified type.
+ *
+ * @typedef Any
+ * @memberof google.protobuf
+ * @see [google.protobuf.Any definition in proto format]{@link https://github.com/google/protobuf/blob/master/src/google/protobuf/any.proto}
+ */
+var Any = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1/doc/google/protobuf/doc_duration.js
+++ b/src/v1/doc/google/protobuf/doc_duration.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/protobuf/doc_field_mask.js
+++ b/src/v1/doc/google/protobuf/doc_field_mask.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/protobuf/doc_struct.js
+++ b/src/v1/doc/google/protobuf/doc_struct.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/protobuf/doc_timestamp.js
+++ b/src/v1/doc/google/protobuf/doc_timestamp.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/protobuf/doc_wrappers.js
+++ b/src/v1/doc/google/protobuf/doc_wrappers.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/src/v1/doc/google/rpc/doc_status.js
+++ b/src/v1/doc/google/rpc/doc_status.js
@@ -1,0 +1,92 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Note: this file is purely for documentation. Any contents are not expected
+// to be loaded as the JS file.
+
+/**
+ * The `Status` type defines a logical error model that is suitable for different
+ * programming environments, including REST APIs and RPC APIs. It is used by
+ * [gRPC](https://github.com/grpc). The error model is designed to be:
+ *
+ * - Simple to use and understand for most users
+ * - Flexible enough to meet unexpected needs
+ *
+ * # Overview
+ *
+ * The `Status` message contains three pieces of data: error code, error message,
+ * and error details. The error code should be an enum value of
+ * google.rpc.Code, but it may accept additional error codes if needed.  The
+ * error message should be a developer-facing English message that helps
+ * developers *understand* and *resolve* the error. If a localized user-facing
+ * error message is needed, put the localized message in the error details or
+ * localize it in the client. The optional error details may contain arbitrary
+ * information about the error. There is a predefined set of error detail types
+ * in the package `google.rpc` that can be used for common error conditions.
+ *
+ * # Language mapping
+ *
+ * The `Status` message is the logical representation of the error model, but it
+ * is not necessarily the actual wire format. When the `Status` message is
+ * exposed in different client libraries and different wire protocols, it can be
+ * mapped differently. For example, it will likely be mapped to some exceptions
+ * in Java, but more likely mapped to some error codes in C.
+ *
+ * # Other uses
+ *
+ * The error model and the `Status` message can be used in a variety of
+ * environments, either with or without APIs, to provide a
+ * consistent developer experience across different environments.
+ *
+ * Example uses of this error model include:
+ *
+ * - Partial errors. If a service needs to return partial errors to the client,
+ *     it may embed the `Status` in the normal response to indicate the partial
+ *     errors.
+ *
+ * - Workflow errors. A typical workflow has multiple steps. Each step may
+ *     have a `Status` message for error reporting.
+ *
+ * - Batch operations. If a client uses batch request and batch response, the
+ *     `Status` message should be used directly inside batch response, one for
+ *     each error sub-response.
+ *
+ * - Asynchronous operations. If an API call embeds asynchronous operation
+ *     results in its response, the status of those operations should be
+ *     represented directly using the `Status` message.
+ *
+ * - Logging. If some API errors are stored in logs, the message `Status` could
+ *     be used directly after any stripping needed for security/privacy reasons.
+ *
+ * @property {number} code
+ *   The status code, which should be an enum value of google.rpc.Code.
+ *
+ * @property {string} message
+ *   A developer-facing error message, which should be in English. Any
+ *   user-facing error message should be localized and sent in the
+ *   google.rpc.Status.details field, or localized by the client.
+ *
+ * @property {Object[]} details
+ *   A list of messages that carry the error details.  There is a common set of
+ *   message types for APIs to use.
+ *
+ *   This object should have the same structure as [Any]{@link google.protobuf.Any}
+ *
+ * @typedef Status
+ * @memberof google.rpc
+ * @see [google.rpc.Status definition in proto format]{@link https://github.com/googleapis/googleapis/blob/master/google/rpc/status.proto}
+ */
+var Status = {
+  // This is for documentation. Actual contents will be loaded by gRPC.
+};

--- a/src/v1/index.js
+++ b/src/v1/index.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,

--- a/system-test/.eslintrc.yml
+++ b/system-test/.eslintrc.yml
@@ -1,6 +1,0 @@
----
-env:
-  mocha: true
-rules:
-  node/no-unpublished-require: off
-  no-console: off

--- a/test/gapic-v1.js
+++ b/test/gapic-v1.js
@@ -1,10 +1,10 @@
-// Copyright 2017, Google LLC All rights reserved.
+// Copyright 2018 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     http://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -51,7 +51,7 @@ describe('DataTransferServiceClient', () => {
       var defaultSchedule = 'defaultSchedule-800168235';
       var supportsCustomSchedule = true;
       var helpUrl = 'helpUrl-789431439';
-      var defaultDataRefreshWindowDays = -1804935157;
+      var defaultDataRefreshWindowDays = 1804935157;
       var manualRunsDisabled = true;
       var expectedResponse = {
         name: name2,
@@ -203,7 +203,7 @@ describe('DataTransferServiceClient', () => {
       var schedule = 'schedule-697920873';
       var dataRefreshWindowDays = 327632845;
       var disabled = true;
-      var userId = -147132913;
+      var userId = 147132913;
       var datasetRegion = 'datasetRegion959248539';
       var expectedResponse = {
         name: name,
@@ -283,7 +283,7 @@ describe('DataTransferServiceClient', () => {
       var schedule = 'schedule-697920873';
       var dataRefreshWindowDays = 327632845;
       var disabled = true;
-      var userId = -147132913;
+      var userId = 147132913;
       var datasetRegion = 'datasetRegion959248539';
       var expectedResponse = {
         name: name,
@@ -424,7 +424,7 @@ describe('DataTransferServiceClient', () => {
       var schedule = 'schedule-697920873';
       var dataRefreshWindowDays = 327632845;
       var disabled = true;
-      var userId = -147132913;
+      var userId = 147132913;
       var datasetRegion = 'datasetRegion959248539';
       var expectedResponse = {
         name: name2,
@@ -645,7 +645,7 @@ describe('DataTransferServiceClient', () => {
       var name2 = 'name2-1052831874';
       var destinationDatasetId = 'destinationDatasetId1541564179';
       var dataSourceId = 'dataSourceId-1015796374';
-      var userId = -147132913;
+      var userId = 147132913;
       var schedule = 'schedule-697920873';
       var expectedResponse = {
         name: name2,


### PR DESCRIPTION
New GAPIC code brings in incompatible proto changes, but since we're still in alpha, it's OK to just bump a semver minor version. I'll mention the changes in the release notes.