### PR TITLE
chore: one more workaround for repo-tools EPERM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,7 +176,12 @@ jobs:
                 -k "${SYSTEM_TESTS_ENCRYPTION_KEY}"
       - run:
           name: Install modules and dependencies.
-          command: npm install
+          command: |-
+            npm install
+            repo_tools="node_modules/@google-cloud/nodejs-repo-tools/bin/tools"
+            if ! test -x "$repo_tools"; then
+              chmod +x "$repo_tools"
+            fi
       - run:
           name: Run system tests.
           command: npm run system-test


### PR DESCRIPTION
Sometimes it just happens, only in CircleCI and never reproduced. Here is a proof that this `chmod` fixes the problem: https://circleci.com/gh/googleapis/nodejs-speech/1376 - let's apply this to all our repos and see if it fails or not.

This PR fixes system tests and sample tests which were missed by previous PR.