### PR TITLE
Release nodejs-bigquery-data-transfer v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Implementation Changes
 - Re-generate library using /synth.py (#51)
-- refactor: drop repo-tool as an exec wrapper (#42)
+ - Interal proto changes (additional bindings)
+ - DEPRECATION: transfer_type field option has no effect
+ - See: https://github.com/googleapis/googleapis/compare/abe00527f...master
 
 #### BREAKING CHANGE
 In this version we dropped support for NodeJS 4.x and 9.x. Your code might break if you're using this library on non LTS versions.
@@ -20,6 +22,7 @@ In this version we dropped support for NodeJS 4.x and 9.x. Your code might break
 - fix: update all dependencies (#33)
 
 ### Internal / Testing Changes
+- refactor: drop repo-tool as an exec wrapper (#42)
 - fix: update linking for samples (#39)
 - Configure Renovate (#37)
 - update gax and synth.py (#43)
@@ -31,4 +34,3 @@ In this version we dropped support for NodeJS 4.x and 9.x. Your code might break
 - chore: workaround for repo-tools EPERM (#25)
 - chore: make samples depend on the current version (#24)
 - chore: setup nighty build in CircleCI (#23)
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 [npm history][1]
 
-[1]: https://www.npmjs.com/package/PACKAGE NAME?activeTab=versions
+[1]: https://www.npmjs.com/package/@google-cloud/bigquery-data-transfer?activeTab=versions
 
 ## v0.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,34 @@
+# Changelog
+
+[npm history][1]
+
+[1]: https://www.npmjs.com/package/PACKAGE NAME?activeTab=versions
+
+## v0.4.0
+
+### Implementation Changes
+- Re-generate library using /synth.py (#51)
+- refactor: drop repo-tool as an exec wrapper (#42)
+
+#### BREAKING CHANGE
+In this version we dropped support for NodeJS 4.x and 9.x. Your code might break if you're using this library on non LTS versions.
+- fix: drop support for node.js 4.x and 9.x (#47)
+
+### Dependencies
+- chore(deps): update dependency eslint to v5 (#44)
+- chore(package): update nyc to version 12.0.2 (#35)
+- fix: update all dependencies (#33)
+
+### Internal / Testing Changes
+- fix: update linking for samples (#39)
+- Configure Renovate (#37)
+- update gax and synth.py (#43)
+- chore(build): use `npm ci` instead of `npm install` (#49)
+- chore: the ultimate fix for repo-tools EPERM (#31)
+- chore: timeout for system test (#30)
+- chore: test on node10 (#28)
+- chore: one more workaround for repo-tools EPERM (#26)
+- chore: workaround for repo-tools EPERM (#25)
+- chore: make samples depend on the current version (#24)
+- chore: setup nighty build in CircleCI (#23)
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@google-cloud/bigquery-data-transfer",
   "description": "BigQuery Data Transfer API client for Node.js",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "Apache-2.0",
   "author": "Google Inc",
   "engines": {


### PR DESCRIPTION
This pull request was generated using releasetool.